### PR TITLE
Don't create PVC if existingClaim is set

### DIFF
--- a/bitwardenrs/templates/pvc.yaml
+++ b/bitwardenrs/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
First of all thanks for creating this chart! It looks very promising so far :)

I came across the issue that the `PVC` was created even though an `existingClaim` was set. This PR adds a check to not render the `PVC` when `existingClaim` is set.
Should I bump the `version` to `0.1.3`?