### PR TITLE
Extra Env variables and Traefik middleware

### DIFF
--- a/bitwardenrs/Chart.yaml
+++ b/bitwardenrs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.15.1
 keywords:
   - bitwarden

--- a/bitwardenrs/README.md
+++ b/bitwardenrs/README.md
@@ -34,6 +34,7 @@ bitwardenrs.verifySignup | Verify e-mail before login is enabled. SMTP must be e
 bitwardenrs.allowInvitation | Allow invited users to sign-up even feature is disabled. [More information](https://github.com/dani-garcia/bitwarden_rs/wiki/Disable-invitations) | true / false | true
 bitwardenrs.showPasswordHint | Show password hints. [More Information](https://github.com/dani-garcia/bitwarden_rs/wiki/Password-hint-display) | true / false | true
 bitwardenrs.enableWebsockets | Enable Websockets for notification. [More Information](https://github.com/dani-garcia/bitwarden_rs/wiki/Enabling-WebSocket-notifications). If using Ingress controllers, "notifications/hub" URL is redirected to websocket port | true / false | true
+bitwardenrs.extraEnv | Pass extra environment variables | Map | Not defined
 bitwardenrs.log.file | Filename to log to disk. [More information](https://github.com/dani-garcia/bitwarden_rs/wiki/Logging) | File path | Empty
 bitwardenrs.log.level | Change log level | trace, debug, info, warn, error or off | Empty
 
@@ -81,6 +82,7 @@ ingress.tls | Ingress TLS options | Array of Maps | Empty
 |||
 ingressRoute.enabled | Enable Traefik IngressRoute CRD | true / false | false
 ingressRoute.host | Ingress route hostname **required** | Hostname | Empty
+ingressRoute.middlewares | Enable middlewares | Map | Empty
 ingressRoute.entrypoints | List of Traefik endpoints | Array of Text | \[websecure\]
 ingressRoute.tls | Ingress route TLS options | Map | Empty
 

--- a/bitwardenrs/templates/deployment.yaml
+++ b/bitwardenrs/templates/deployment.yaml
@@ -53,6 +53,12 @@ spec:
               value: {{ .Values.bitwardenrs.showPasswordHint | quote }}
             - name: WEBSOCKET_ENABLED
               value: {{ .Values.bitwardenrs.enableWebsockets | quote }}
+            {{- if .Values.bitwardenrs.extraEnv }}
+            {{- range $key, $val := .Values.bitwardenrs.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- end }}
             {{- if eq .Values.database.type "sqlite" }}
             - name: ENABLE_DB_WAL
               value: {{ .Values.database.wal | quote }}

--- a/bitwardenrs/templates/ingressroute.yaml
+++ b/bitwardenrs/templates/ingressroute.yaml
@@ -16,12 +16,20 @@ spec:
   {{- if .Values.bitwardenrs.enableWebsockets }}
   - match: Host(`{{ $host }}`) && PathPrefix(`/notifications/hub`)
     kind: Rule
+    {{- if .Values.ingressRoute.middlewares }}
+    middlewares:
+      {{- toYaml .Values.ingressRoute.middlewares | nindent 6 }}
+    {{- end }}
     services:
     - name: {{ $fullName }} 
       port: {{ .Values.service.websocketPort }}
   {{- end }}
   - match: Host(`{{ $host }}`)
     kind: Rule
+    {{- if .Values.ingressRoute.middlewares }}
+    middlewares:
+      {{- toYaml .Values.ingressRoute.middlewares | nindent 6 }}
+    {{- end }}
     services:
     - name: {{ $fullName }}
       port: {{ .Values.service.httpPort }}

--- a/bitwardenrs/values.yaml
+++ b/bitwardenrs/values.yaml
@@ -28,6 +28,9 @@ bitwardenrs:
   # Enable Websockets for notification. https://github.com/dani-garcia/bitwarden_rs/wiki/Enabling-WebSocket-notifications
   # Redirect HTTP path "/notifications/hub" to port 3012. Ingress/IngressRoute controllers are automatically configured.
   enableWebsockets: true
+  # Pass extra environment variables, use carefully.
+  #extraEnv:
+  #  ROCKET_ENV: staging
 
   admin:
     # Enable admin portal.
@@ -105,6 +108,10 @@ ingressRoute:
   enabled: false
   # Mandatory to enable IngressRoute
   host: ""
+  # Enable middlewares on the route
+  middlewares: {}
+  #  - name: my_middleware
+  #    namespace: default
   entrypoints:
     - websecure
   tls: {}


### PR DESCRIPTION
Allow option to inject environment variables manually.
Add option to select middlewares for Traefik IngressRoute.

@Ornias1993 Can you test please? I have based this out of your patches but fixed the middleware. They are placed at "route" level instead of top-level like TLS or entrypoints.

Replaces #7, fixes #4 and #5.