### PR TITLE
allow custom volumes

### DIFF
--- a/bitwardenrs/README.md
+++ b/bitwardenrs/README.md
@@ -101,6 +101,7 @@ persistence.size | Size of volume | Size | 1Gi
 persistence.accessMode | Volume access mode | Text | ReadWriteOnce
 persistence.storageClass | Storage Class | Text | Not defined. Use "-" for default class
 persistence.existingClaim | Use existing PVC | Name of PVC | Not defined
+customVolume | Use custom volume definition. Cannot be used with persistence | Map | Empty
 
 ## **Image**
 

--- a/bitwardenrs/templates/deployment.yaml
+++ b/bitwardenrs/templates/deployment.yaml
@@ -190,9 +190,14 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
       - name: {{ include "bitwardenrs.fullname" . }}
+        {{- if and .Values.persistence.enabled .Values.customVolume }}
+          {{ required "customVolume cannot be used if persistence is enabled." nil }}
+        {{- end }}
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim | quote }}{{- else }}{{ include "bitwardenrs.fullname" . }}{{- end }}
+        {{- else if .Values.customVolume }}
+          {{- toYaml .Values.customVolume | nindent 8 }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/bitwardenrs/values.yaml
+++ b/bitwardenrs/values.yaml
@@ -138,6 +138,12 @@ persistence:
   ## Use existing Persistent Volume Claim
   # existingClaim:
 
+
+# Use custom volume definition. Cannot be used with persistence.
+customVolume: {}
+  #hostPath:
+  #  path: "/examplefolder/bitwardenrs"
+
 image:
   pullPolicy: IfNotPresent
   tag: ""


### PR DESCRIPTION
This commits adds the option to setup custom volumes without PVC
This might be prefered in some situations where one wants a hostpath without pvc.

Update to docs is included.

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>