### PR TITLE
feat: add missing env configs and session storage definition

### DIFF
--- a/leantime/README.md
+++ b/leantime/README.md
@@ -57,6 +57,8 @@ leantime.existingSecret | Use existing secret for session salt. Key is 'session-
 Option | Description | Format | Default
 ------ | ----------- | ------ | -------
 leantime.s3.enabled | Enable S3 File storage | true / false | false
+leantime.s3.endpoint | custom https endpoint | empty or https url| empty
+leantime.s3.usePathStyleEndpoint | switch between path or subdomain style endpoint url | true / false | false
 leantime.s3.key | S3 Key **(required)** | Text | Empty
 leantime.s3.secret | S3 Secret **(required)** | Text | Empty
 leantime.s3.bucket | S3 Bucket **(required)** | Text | Empty
@@ -73,7 +75,8 @@ leantime.smtp.existingSecret | Use existing secret for SMTP username and passwor
 leantime.smtp.port | Use non-standard SMTP port | Number | Default SMTP ports
 leantime.smtp.secureProtocol | Force specific security protocol | tls, ssl or starttls | Auto-detect
 leantime.smtp.autoTLS | Enable TLS automatically if supported by server | true / false | true
-
+|||
+leantime.env | custom env variables to be more flexible with custom images | array of env variables | empty
 ## **Network**
 
 Option | Description | Format | Default
@@ -105,6 +108,12 @@ persistence.size | Size of volume | Size | 1Gi
 persistence.accessMode | Volume access mode | Text | ReadWriteOnce
 persistence.storageClass | Storage Class | Text | Not defined. Use "-" for default class
 persistence.existingClaim | Use existing PVC | Name of PVC | Not defined
+|||
+sessionstorage.enabled | Use persistent volume (PVC) for user sessions. Mounts to /sessions | true / false | false
+sessionstorage.size | Size of volume | Size | 1Gi
+persissessionstoragetence.accessMode | Volume access mode | Text | ReadWriteOnce
+sessionstorage.storageClass | Storage Class | Text | Not defined. Use "-" for default class
+sessionstorage.existingClaim | Use existing PVC | Name of PVC | Not defined
 |||
 internalDatabase.persistence.enabled | Use persistent volume (PVC) for MariaDB database | true / false | false
 internalDatabase.persistence.size | Size of volume | Size | 2Gi

--- a/leantime/templates/deployment.yaml
+++ b/leantime/templates/deployment.yaml
@@ -83,6 +83,14 @@ spec:
             {{- if eq .Values.leantime.s3.enabled true}}
             - name: LEAN_USE_S3
               value: "true"
+            {{- if .Values.leantime.s3.endpoint }}
+            - name: LEAN_S3_END_POINT
+              value: {{ .Values.leantime.s3.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.leantime.s3.usePathStyleEndpoint }}
+            - name: LEAN_S3_USE_PATH_STYLE_ENDPOINT
+              value: {{ .Values.leantime.s3.usePathStyleEndpoint | quote }}
+            {{- end }}
             - name: LEAN_S3_BUCKET
               value: {{ required "Bucket name required to enable S3" .Values.leantime.s3.bucket | quote }}
             - name: LEAN_S3_REGION
@@ -132,6 +140,9 @@ spec:
                   name: {{ default (include "leantime.fullname" .) .Values.leantime.smtp.existingSecret }}
                   key: smtp-password
             {{- end }}
+{{- if .Values.leantime.env }}
+{{ toYaml .Values.leantime.env | indent 8 }}
+{{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -151,6 +162,8 @@ spec:
           - name: {{ include "leantime.fullname" . }}
             mountPath: /var/www/html/public/userfiles
             subPath: public-userfiles
+          - name: {{ include "leantime.fullname" . }}-sessions
+            mountPath: /sessions
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if eq .Values.internalDatabase.enabled true }}
@@ -208,6 +221,13 @@ spec:
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim | quote }}{{- else }}{{ include "leantime.fullname" . }}{{- end }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      - name: {{ include "leantime.fullname" . }}-sessions
+        {{- if .Values.sessionstorage.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.sessionstorage.existingClaim }}{{ .Values.sessionstorage.existingClaim | quote }}{{- else }}{{ include "leantime.fullname" . }}-sessions{{- end }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/leantime/templates/pvc-sessions.yaml
+++ b/leantime/templates/pvc-sessions.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.sessionstorage.enabled (not .Values.sessionstorage.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "leantime.fullname" . }}-sessions
+spec:
+  accessModes:
+    - {{ .Values.sessionstorage.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.sessionstorage.size | quote }}
+  {{- if .Values.sessionstorage.storageClass }}
+  storageClassName: {{ .Values.sessionstorage.storageClass | quote }}
+  {{- end }}
+{{- end -}}

--- a/leantime/values.yaml
+++ b/leantime/values.yaml
@@ -58,10 +58,14 @@ leantime:
   ## Session expiration. Defaults to 8 hours (28800s).
   #sessionExpiration:
   ## Use existing secret for session salt. Key is 'session-salt'.
-  #existingSecret: 
+  #existingSecret:
 
   s3:
     enabled: false
+    # S3 endpoint (empty | https://my-minio_host)
+    endpoint: ""
+    # S3 use path style of subdomain style (true ==> https://[endpoint]/[bucket] ; false => https://[bucket].[endpoint])
+    usePathStyleEndpoint: false
     ## S3 Key (required)
     key: ""
     ## S3 Secret (required)
@@ -71,9 +75,9 @@ leantime:
     ## S3 Region (required)
     region: ""
     ## S3 sub-folder
-    #folder: 
+    #folder:
     ## Use existing secret for S3 key and secret. Keys are 's3-key' and 's3-secret'
-    #existingSecret: 
+    #existingSecret:
 
   smtp:
     enabled: false
@@ -88,11 +92,12 @@ leantime:
     ## SMTP port
     #port:
     ## Force specific security protocol (tls, ssl or starttls).
-    #secureProtocol: 
+    #secureProtocol:
     ## Enable TLS automatically if supported by server. Enabled by default.
     #autoTLS: false
     ## Use existing secret for SMTP username and password. Keys are 'smtp-user' and 'smtp-password'
-    #existingSecret: 
+    #existingSecret:
+  env: []
 
 service:
   type: ClusterIP
@@ -107,7 +112,8 @@ service:
 ingress:
   enabled: false
   host: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls: []
@@ -122,7 +128,8 @@ ingressRoute:
   host: ""
   entrypoints:
     - websecure
-  tls: []
+  tls:
+    []
     #certResolver: letsencrypt
 
 # Enable persistent storage for user files.
@@ -135,7 +142,14 @@ persistence:
   # storageClass: "-"
   ## Use existing Persistent Volume Claim
   # existingClaim:
-
+sessionstorage:
+  enabled: false
+  size: 1Gi
+  accessMode: ReadWriteOnce
+  ## Persistent Volume storage class
+  # storageClass: "-"
+  ## Use existing Persistent Volume Claim
+  # existingClaim:
 image:
   repository: leantime/leantime
   pullPolicy: IfNotPresent
@@ -159,10 +173,12 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -170,7 +186,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
This PR improves the handling of S3 configuration and adds an additional env array, which can be passed to configure custom-build images.
A PVC is also added to allow sessions to service a pod restart. 

This PR relates to the following 3 PRs:
* https://github.com/Leantime/leantime/pull/381
* https://github.com/Leantime/leantime/pull/380
* https://github.com/Leantime/docker-leantime/pull/31

A docker image we use internally in our company, which has all these PRs enabled, can be found on docker hub: https://hub.docker.com/r/droidsolutions/leantime