### PR TITLE
feat: support v1 Ingress

### DIFF
--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -105,6 +105,7 @@ service.nodePorts.http | Manually select node port for http | Number | Empty
 service.nodePorts.websocket | Manually select node port for websocker, if enabled | Number | Empty
 |||
 ingress.enabled | Enable Ingress | true / false | false
+ingress.className | Name of the ingress class | string | Empty
 ingress.host | Ingress hostname **required** | Hostname | Empty
 ingress.annotations | Ingress annotations | Map | Empty
 ingress.tls | Ingress TLS options | Array of Maps | Empty

--- a/vaultwarden/templates/ingress.yaml
+++ b/vaultwarden/templates/ingress.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "vaultwarden.fullname" . -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -15,6 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -31,12 +36,32 @@ spec:
         paths:
           {{- if .Values.vaultwarden.enableWebsockets }}
           - path: "/notifications/hub"
+            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .Values.service.websocketPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ .Values.service.websocketPort }}
+              {{- end }}
           {{- end }}
           - path: "/"
+            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .Values.service.httpPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ .Values.service.httpPort }}
+              {{- end }}
 {{- end }}

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -137,6 +137,7 @@ service:
 # Kubernetes Ingress
 ingress:
   enabled: false
+  # className: nginx
   host: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Per Kubernetes 1.22, v1beta1 ingress is dropped. This commit autodetects ingress capabilites and templates correct ingress (legacy extensions/v1beta1, networking/v1beta1 and networking/v1), including optional ingress class name.

As I do not have a < 1.18 cluster (ie, without networking/v1) around or even < 1.16 (without v1beta1) I have not been able to test if the old templating actually works. 