### PR TITLE
Added support for adding annotations in Deployment

### DIFF
--- a/bitwardenrs/README.md
+++ b/bitwardenrs/README.md
@@ -148,6 +148,7 @@ fullnameOverride | Full name override | Text | Empty
 serviceAccount.create | Create Service Account | true / false | false
 serviceAccount.annotations | Annotations service account | Map | Empty
 serviceAccount.name | Service Account name | Text | Generated from template
+deploymentAnnotations | Deployment Annotations | Map | Empty
 podAnnotations | Pod Annotations | Map | Empty
 podLabels | Extra Pod Labels | Map | Empty
 podSecurityContext | Pod-level Security Context | Map | {fsGroup:65534}

--- a/bitwardenrs/templates/deployment.yaml
+++ b/bitwardenrs/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "bitwardenrs.fullname" . }}
   labels:
     {{- include "bitwardenrs.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.strategy }}
   strategy:

--- a/bitwardenrs/values.yaml
+++ b/bitwardenrs/values.yaml
@@ -213,6 +213,10 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+
+# Annotations to add to the Deployment
+deploymentAnnotations: {}
+
 podSecurityContext:
   fsGroup: 65534
 

--- a/leantime/README.md
+++ b/leantime/README.md
@@ -145,6 +145,7 @@ fullnameOverride | Full name override | Text | Empty
 serviceAccount.create | Create Service Account | true / false | false
 serviceAccount.annotations | Annotations service account | Map | Empty
 serviceAccount.name | Service Account name | Text | Generated from template
+deploymentAnnotations | Deployment Annotations | Map | Empty
 podAnnotations | Pod Annotations | Map | Empty
 podLabels | Extra Pod Labels | Map | Empty
 podSecurityContext | Pod-level Security Context | Map | Empty

--- a/leantime/templates/deployment.yaml
+++ b/leantime/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "leantime.fullname" . }}
   labels:
     {{- include "leantime.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.strategy }}
   strategy:

--- a/leantime/values.yaml
+++ b/leantime/values.yaml
@@ -174,6 +174,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Annotations to add to the Deployment
+deploymentAnnotations: {}
+
 podAnnotations: {}
 podLabels: {}
 

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -153,6 +153,7 @@ fullnameOverride | Full name override | Text | Empty
 serviceAccount.create | Create Service Account | true / false | false
 serviceAccount.annotations | Annotations service account | Map | Empty
 serviceAccount.name | Service Account name | Text | Generated from template
+deploymentAnnotations | Deployment Annotations | Map | Empty
 podAnnotations | Pod Annotations | Map | Empty
 podLabels | Extra Pod Labels | Map | Empty
 podSecurityContext | Pod-level Security Context | Map | {fsGroup:65534}

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "vaultwarden.fullname" . }}
   labels:
     {{- include "vaultwarden.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.strategy }}
   strategy:

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -213,6 +213,9 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+# Annotations to add to the Deployment
+deploymentAnnotations: {}
+
 podSecurityContext:
   fsGroup: 65534
 


### PR DESCRIPTION
I added support for adding deployment annotations. I would like to have it so I can enable [keel](https://keel.sh/) to scan deployments for newer images