### PR TITLE
Database url hint should include database name

### DIFF
--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -5,7 +5,7 @@ database:
   type: sqlite
   # Enable DB Write-Ahead-Log for SQLite, disabled for other databases. https://github.com/dani-garcia/vaultwarden/wiki/Running-without-WAL-enabled
   wal: true
-  ## URL for external databases (mysql://user:pass@host:port or postgresql://user:pass@host:port).
+  ## URL for external databases (mysql://user:pass@host:port/database-name or postgresql://user:pass@host:port/database-name).
   #url: ""
   ## Use existing secret for database URL, key 'database-url'.
   #existingSecret:


### PR DESCRIPTION
Database url hint should include database name. Because otherwise it will silently fall back to sqlite. I saw someone created a PR to fix the unintended fallback to sqlite. But this is just the config hint. I hope it will save someone some time figuring out why their database url is not working.