### PR TITLE
feat: Add options to enable TLS using sidecars

### DIFF
--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: ROCKET_PORT
-              value: "8080"
+              value: {{ .Values.vaultwarden.rocketPort | quote }} 
             - name: SIGNUPS_ALLOWED
               value: {{ .Values.vaultwarden.allowSignups | quote }}
             {{- if .Values.vaultwarden.signupDomains }}
@@ -267,12 +267,12 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: {{ include "vaultwarden.domainSubPath" . }}
-              port: http
+              path: /
+              port: {{ .Values.vaultwarden.rocketPort }}
           readinessProbe:
             httpGet:
-              path: {{ include "vaultwarden.domainSubPath" . }}
-              port: http
+              path: /
+              port: {{ .Values.vaultwarden.rocketPort }}
           volumeMounts:
           - name: {{ include "vaultwarden.fullname" . }}
             mountPath: /data
@@ -282,6 +282,9 @@ spec:
         {{- toYaml .Values.sidecars | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}
       - name: {{ include "vaultwarden.fullname" . }}
         {{- if and .Values.persistence.enabled .Values.customVolume }}
           {{ required "customVolume cannot be used if persistence is enabled." nil }}

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -46,6 +46,8 @@ vaultwarden:
   enableSends: true
   # Restrict creation of orgs. Options are: 'all', 'none' or a comma-separated list of users.
   orgCreationUsers: all
+  # Specify container rocket port
+  rocketPort: 8080
   ## Limit attachment disk usage per organization.
   #attachmentLimitOrg: 
   ## Limit attachment disk usage per user.
@@ -254,3 +256,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Specify additional volumes. This can be useful when using sidecars.
+extraVolumes: {}


### PR DESCRIPTION
This PR allow customization of the `rocketPort`. This was necessary, since we wanted to use a reverse proxy without using rocket for TLS in our kubernetes cluster. 

Additionally, this PR also alters the `livenessprobe` in order to use a container-internal connection and we introduced a new option that allows specifying additional volumes. This is necessary in order to properly work with sidecars.

Co-authored-by: @p-fruck