### PR TITLE
Vaultwarden 1.27

### DIFF
--- a/bitwardenrs/README.md
+++ b/bitwardenrs/README.md
@@ -1,7 +1,8 @@
 # Gissilabs Helm Charts
 
 ## Deprecation notice
-The upstream project changed its name from bitwarden_rs to Vaultwarden on April 27th, 2021, a new "vaultwarden" chart is available. Please migrate to the new chart as soon as possible. To migrate, the only difference is the top-level level value was renamed from "bitwardenrs" to "vaultwarden". All other options remain identical.
+
+The upstream project changed its name from bitwarden_rs to Vaultwarden on April 27th, 2021, a new "vaultwarden" chart is available. Please migrate to the new chart as soon as possible. To migrate, the only difference is the top-level level value was renamed from "bitwardenrs" to "vaultwarden". All other options remain identical. As of January, 2023 this chart is no longer being updated and will be removed by April, 2023.
 
 ## Vaultwarden
 

--- a/bitwardenrs/templates/NOTES.txt
+++ b/bitwardenrs/templates/NOTES.txt
@@ -1,5 +1,5 @@
 ****
-Important Notice: This chart has been replaced by the vaultwarden chart and will be deprecated soon.
+Important Notice: This chart has been replaced by the vaultwarden chart and is deprecated. No further updates as of January, 2023.
 Minimal changes are required to use the new chart, see its README for details.
 ****
 

--- a/vaultwarden/Chart.yaml
+++ b/vaultwarden/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vaultwarden
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 0.5.1
-appVersion: 1.25.1
+version: 1.0.0
+appVersion: 1.27.0
 icon: https://upload.wikimedia.org/wikipedia/commons/0/03/Bitwarden_Logo.png
 home: https://github.com/dani-garcia/vaultwarden
   - bitwarden

--- a/vaultwarden/Chart.yaml
+++ b/vaultwarden/Chart.yaml
@@ -3,7 +3,7 @@ name: vaultwarden
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
 version: 0.5.1
-appVersion: 1.23.0
+appVersion: 1.25.1
 icon: https://upload.wikimedia.org/wikipedia/commons/0/03/Bitwarden_Logo.png
 home: https://github.com/dani-garcia/vaultwarden
   - bitwarden

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -64,6 +64,17 @@ vaultwarden.log.level | Change log level | trace, debug, info, warn, error or of
 vaultwarden.log.timeFormat | Log timestamp | Rust chrono [format](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html). | Time in milliseconds | Empty
 
 ## **Application Features**
+:warning: NOTE: Vaultwarden version before v1.25.0 had a bug/mislabelled configuration setting regarding SSL and TLS. This has been fixed in testing and newer released versions.
+
+The old settings were SMTP_SSL and SMTP_EXPLICIT_TLS, represented by values vaultwarden.smtp.ssl and vaultwarden.smtp.explicitTLS
+
+The new setting is SMTP_SECURITY, represented by value vaultwarden.smtp.security, which has the following options: starttls, force_tls and off.
+
+SMTP_SSL (vaultwarden.smtp.ssl) =true equals vaultwarden.smtp.security =starttls
+
+SMTP_EXPLICIT_TLS (vaultwarden.smtp.explicitTLS) =true equals vaultwarden.smtp.security =force_tls
+
+SMTP_SECURITY (vaultwarden.smtp.security) default value is 'off'
 
 Option | Description | Format | Default
 ------ | ----------- | ------ | -------
@@ -80,8 +91,7 @@ vaultwarden.smtp.enabled | Enable SMTP | true / false | false
 vaultwarden.smtp.host | SMTP hostname **required** | Hostname | Empty
 vaultwarden.smtp.from | SMTP sender e-mail address **required** | E-mail | Empty
 vaultwarden.smtp.fromName | SMTP sender name | Text | Vaultwarden
-vaultwarden.smtp.ssl | Enable SSL connection | true / false | true
-vaultwarden.smtp.explicitTLS | Use Explicit TLS mode **requires SSL** | true / false | false
+vaultwarden.smtp.security | Enable SSL connection | starttls / force_tls / off | off
 vaultwarden.smtp.port | SMTP TCP port | Number | SSL Enabled: 587. SSL Disabled: 25
 vaultwarden.smtp.authMechanism | SMTP Authentication Mechanisms | Comma-separated list: 'Plain', 'Login', 'Xoauth2' | Plain
 vaultwarden.smtp.heloName | Hostname to be sent for SMTP HELO | Text | Pod name

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -64,17 +64,8 @@ vaultwarden.log.level | Change log level | trace, debug, info, warn, error or of
 vaultwarden.log.timeFormat | Log timestamp | Rust chrono [format](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html). | Time in milliseconds | Empty
 
 ## **Application Features**
-:warning: NOTE: Vaultwarden version before v1.25.0 had a bug/mislabelled configuration setting regarding SSL and TLS. This has been fixed in testing and newer released versions.
 
-The old settings were SMTP_SSL and SMTP_EXPLICIT_TLS, represented by values vaultwarden.smtp.ssl and vaultwarden.smtp.explicitTLS
-
-The new setting is SMTP_SECURITY, represented by value vaultwarden.smtp.security, which has the following options: starttls, force_tls and off.
-
-SMTP_SSL (vaultwarden.smtp.ssl) =true equals vaultwarden.smtp.security =starttls
-
-SMTP_EXPLICIT_TLS (vaultwarden.smtp.explicitTLS) =true equals vaultwarden.smtp.security =force_tls
-
-SMTP_SECURITY (vaultwarden.smtp.security) default value is 'off'
+:warning: SMTP SSL/TLS settings changed following Vaultwarden v1.25 release, see [Upgrade](#upgrade)
 
 Option | Description | Format | Default
 ------ | ----------- | ------ | -------
@@ -84,15 +75,15 @@ vaultwarden.admin.token | Token for admin login, will be generated if not define
 vaultwarden.admin.existingSecret | Use existing secret for the admin token. Key is 'admin-token' | Secret name | Not defined
 |||
 vaultwarden.emergency.enabled | Allow any user to enable emergency access. | true / false | true
-vaultwarden.emergency.reminder | Schedule to send expiration reminders to emergency access grantors. | Cron schedule format, blank to disable | "0 5 * * * *" (hourly 5 minutes after the hour)
-vaultwarden.emergency.timeout | Schedule to grant emergency access requests that have met the required wait time. | Cron schedule format, blank to disable | "0 5 * * * *" (hourly 5 minutes after the hour)
+vaultwarden.emergency.reminder | Schedule to send expiration reminders to emergency access grantors. | Cron schedule format, blank to disable | "0 3 \* \* \* \*" (hourly 3 minutes after the hour)
+vaultwarden.emergency.timeout | Schedule to grant emergency access requests that have met the required wait time. | Cron schedule format, blank to disable | "0 3 \* \* \* \*" (hourly 3 minutes after the hour)
 |||
 vaultwarden.smtp.enabled | Enable SMTP | true / false | false
 vaultwarden.smtp.host | SMTP hostname **required** | Hostname | Empty
 vaultwarden.smtp.from | SMTP sender e-mail address **required** | E-mail | Empty
 vaultwarden.smtp.fromName | SMTP sender name | Text | Vaultwarden
-vaultwarden.smtp.security | Enable SSL connection | starttls / force_tls / off | off
-vaultwarden.smtp.port | SMTP TCP port | Number | SSL Enabled: 587. SSL Disabled: 25
+vaultwarden.smtp.security | Set SMTP connection security [More Information](https://github.com/dani-garcia/vaultwarden/wiki/SMTP-Configuration) | starttls / force_tls / off | starttls
+vaultwarden.smtp.port | SMTP TCP port | Number | Security off: 25, starttls: 587, force_tls: 465
 vaultwarden.smtp.authMechanism | SMTP Authentication Mechanisms | Comma-separated list: 'Plain', 'Login', 'Xoauth2' | Plain
 vaultwarden.smtp.heloName | Hostname to be sent for SMTP HELO | Text | Pod name
 vaultwarden.smtp.timeout | SMTP connection timeout in seconds | Number | 15
@@ -176,3 +167,16 @@ resources | Deployment Resources | Map | Empty
 nodeSelector | Node selector | Map | Empty
 tolerations | Tolerations | Array | Empty
 affinity | Affinity | Map | Empty
+
+## Upgrade
+
+### From 0.x to 1.x
+
+Vaultwarden version before v1.25.0 had a [bug/mislabelled](https://github.com/dani-garcia/vaultwarden/issues/851) configuration setting regarding SSL and TLS. This has been fixed in testing and newer released versions. When image version is 1.25 or higher, use vaultwarden.smtp.security instead of vaultwarden.smtp.ssl/vaultwarden.smtp.explicitTLS.
+
+ssl | explicitTLS | security equivalent
+--- | ----------- | -------------------
+false | false | off
+false | true | off
+true | false | starttls
+true | true | force_tls

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -48,7 +48,9 @@ vaultwarden.requireEmail | Require that an e-mail is sucessfully sent before log
 vaultwarden.emailAttempts | Maximum attempts before an email token is reset and a new email will need to be sent | Number | 3
 vaultwarden.emailTokenExpiration | Email token validity in seconds | Number | 600
 vaultwarden.allowInvitation | Allow invited users to sign-up even feature is disabled. [More information](https://github.com/dani-garcia/vaultwarden/wiki/Disable-invitations) | true / false | true
+vaultwarden.invitationExpiration | Number of hours after which tokens expire (organization invite, emergency access, email verification and deletion request | Number (minimum 1) | 120
 vaultwarden.defaultInviteName | Default organization name in invitation e-mails that are not coming from a specific organization. | Text | Vaultwarden
+vaultwarden.passwordHintsAllowed | Allow users to set password hints. Applies to all users. | true / false | true
 vaultwarden.showPasswordHint | Show password hints. [More Information](https://github.com/dani-garcia/vaultwarden/wiki/Password-hint-display) | true / false | false
 vaultwarden.enableWebsockets | Enable Websockets for notification. [More Information](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-WebSocket-notifications). If using Ingress controllers, "notifications/hub" URL is redirected to websocket port | true / false | true
 vaultwarden.enableWebVault | Enable Web Vault static site. [More Information](https://github.com/dani-garcia/vaultwarden/wiki/Disabling-or-overriding-the-Vault-interface-hosting). | true / false | true
@@ -58,6 +60,8 @@ vaultwarden.attachmentLimitOrg | Limit attachment disk usage in Kb per organizat
 vaultwarden.attachmentLimitUser | Limit attachment disk usage in Kb per user | Number | Not defined
 vaultwarden.hibpApiKey | API Key to use HaveIBeenPwned service. Can be purchased at [here](https://haveibeenpwned.com/API/Key) | Text | Not defined
 vaultwarden.autoDeleteDays | Number of days to auto-delete trashed items. | Number | Empty (never auto-delete)
+vaultwarden.orgEvents | Enable Organization event logging | true / false | false
+vaultwarden.orgEventsRetention | Organization event log retention in days | Number | Empty (never delete)
 vaultwarden.extraEnv | Pass extra environment variables | Map | Not defined
 vaultwarden.log.file | Filename to log to disk. [More information](https://github.com/dani-garcia/vaultwarden/wiki/Logging) | File path | Empty
 vaultwarden.log.level | Change log level | trace, debug, info, warn, error or off | Empty
@@ -92,6 +96,7 @@ vaultwarden.smtp.invalidCertificate | Accept invalid certificates. DANGEROUS! | 
 vaultwarden.smtp.user | SMTP username | Text | Not defined
 vaultwarden.smtp.password | SMTP password. Required is user is specified | Text | Not defined
 vaultwarden.smtp.existingSecret | Use existing secret for SMTP authentication. Keys are 'smtp-user' and 'smtp-password' | Secret name | Not defined
+vaultwarden.smtp.embedImages | Embed images as email attachments | true / false | false
 |||
 vaultwarden.yubico.enabled | Enable Yubikey support | true / false | false
 vaultwarden.yubico.server | Yubico server | Hostname | YubiCloud
@@ -99,9 +104,11 @@ vaultwarden.yubico.clientId | Yubico ID | Text | Not defined
 vaultwarden.yubico.secretKey | Yubico Secret Key | Text | Not defined
 vaultwarden.yubico.existingSecret | Use existing secret for ID and Secret. Keys are 'yubico-client-id' and 'yubico-secret-key' | Secret name | Not defined
 |||
+vaultwarden.icons.service | Service to fetch icons from | "internal", "bitwarden", "duckduckgo", "google" or custom URL | internal
 vaultwarden.icons.disableDownload | Disables download of external icons, icons in cache will still be served | true / false | false
 vaultwarden.icons.cache | Cache time-to-live for icons fetched. 0 means no purging | Number | 2592000. If download is disabled, defaults to 0
 vaultwarden.icons.cacheFailed | Cache time-to-live for icons that were not available. 0 means no purging | Number | 2592000
+vaultwarden.icons.redirectCode | HTTP code to use for redirects to an external icon service | true / false | 302
 
 ## **Network**
 

--- a/vaultwarden/templates/_helpers.tpl
+++ b/vaultwarden/templates/_helpers.tpl
@@ -80,6 +80,20 @@ Ensure log type is valid
 {{- end }}
 {{- end }}
 
+{{/*
+Ensure SMTP Security setting is valid
+*/}}
+
+{{- define "vaultwarden.smtpSecurityValid" -}}
+{{- if or (hasKey .Values.vaultwarden.smtp "ssl") (hasKey .Values.vaultwarden.smtp "explicitTLS") }}
+{{- required "SMTP options ssl and explicitTLS are deprecated for Vaulwarden 1.25 or newer, see documentation" nil }}
+{{- end }}
+{{- if not (or (eq .Values.vaultwarden.smtp.security "off") (eq .Values.vaultwarden.smtp.security "starttls") (eq .Values.vaultwarden.smtp.security "force_tls") ) }}
+{{- required "Invalid SMTP security setting, valid options are: off, starttls and force_tls" nil }}
+{{- end }}
+{{- end }}
+
+
 {{- define "vaultwarden.domainSubPath" -}}
 {{- if .Values.vaultwarden.domain }}
 {{- if not (regexMatch "https?:\\/\\/.*?(\\/|$)" .Values.vaultwarden.domain) }}

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -161,21 +161,20 @@ spec:
             - name: SMTP_FROM_NAME
               value: {{ .Values.vaultwarden.smtp.fromName | quote }}
             {{- end }}
-            {{- if semverCompare "<1.25.0" }}
-              {{- required "ATTENTION - variables SMTP_SSL and SMTP_EXPLICIT_TLS are depraceted in Vaultwared 1.25.0 and above." nil }}
+            {{- if semverCompare "<1.25.0" (.Values.image.tag | default .Chart.AppVersion) }}
             - name: SMTP_SSL
-              value: {{ .Values.vaultwarden.smtp.ssl | quote }}
-              {{- if .Values.vaultwarden.smtp.explicitTLS }}
+              value: {{ required "Value smtp.ssl required for Vaultwarden prior to 1.25" .Values.vaultwarden.smtp.ssl | quote }}
+              {{- if required "Value smtp.explictTLS required for Vaultwarden prior to 1.25" .Values.vaultwarden.smtp.explicitTLS }}
                 {{- if (eq .Values.vaultwarden.smtp.ssl false) }}
                   {{- required "Explicit TLS requires SSL to be enabled" nil }}
                 {{- end }}
             - name: SMTP_EXPLICIT_TLS
               value: {{ .Values.vaultwarden.smtp.explicitTLS | quote }}
-            {{- else if semverCompare ">=1.25.0" }}
-              {{- if .Values.vaultwarden.smtp.security }}
+              {{- end}}
+            {{- else }}
+              {{- include "vaultwarden.smtpSecurityValid" . }}
             - name: SMTP_SECURITY
               value: {{ .Values.vaultwarden.smtp.security | quote }}
-              {{- end }}
             {{- end }}
             {{- if .Values.vaultwarden.smtp.port }}
             - name: SMTP_PORT

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -67,9 +67,17 @@ spec:
             {{- end }}
             - name: INVITATIONS_ALLOWED
               value: {{ .Values.vaultwarden.allowInvitation | quote }}
+            {{- if .Values.vaultwarden.invitationExpiration }}
+            - name: INVITATION_EXPIRATION_HOURS
+              value: {{ .Values.vaultwarden.invitationExpiration | quote }}
+            {{- end }}
             {{- if .Values.vaultwarden.defaultInviteName }}
             - name: INVITATION_ORG_NAME
               value: {{ .Values.vaultwarden.defaultInviteName | quote }}
+            {{- end }}
+            {{- if hasKey .Values.vaultwarden "passwordHintsAllowed" }}
+            - name: PASSWORD_HINTS_ALLOWED
+              value: {{ .Values.vaultwarden.passwordHintsAllowed | quote }}
             {{- end }}
             - name: SHOW_PASSWORD_HINT
               value: {{ .Values.vaultwarden.showPasswordHint | quote }}
@@ -96,6 +104,14 @@ spec:
             {{- if .Values.vaultwarden.autoDeleteDays }}
             - name: TRASH_AUTO_DELETE_DAYS
               value: {{ .Values.vaultwarden.autoDeleteDays | quote }}
+            {{- end }}
+            {{- if hasKey .Values.vaultwarden "orgEvents" }}
+            - name: ORG_EVENTS_ENABLED
+              value: {{ .Values.vaultwarden.orgEvents | quote }}
+            {{- end }}
+            {{- if hasKey .Values.vaultwarden "orgEventsRetention" }}
+            - name: EVENTS_DAYS_RETAIN
+              value: {{ .Values.vaultwarden.orgEventsRetention | quote }}
             {{- end }}
             {{- if .Values.vaultwarden.extraEnv }}
             {{- range $key, $val := .Values.vaultwarden.extraEnv }}
@@ -212,7 +228,11 @@ spec:
                   name: {{ .Values.vaultwarden.smtp.existingSecret | default (include "vaultwarden.fullname" .) }}
                   key: smtp-password
             {{- end }}
-            {{- end }}
+            {{- if hasKey .Values.vaultwarden.smtp "embedImages" }}
+            - name: SMTP_EMBED_IMAGES
+              value: {{ .Values.vaultwarden.smtp.embedImages | quote }}
+            {{- end }}            
+            {{- end }}{{/*SMTP*/}}
             {{- if eq .Values.vaultwarden.yubico.enabled true }}
             {{- if .Values.vaultwarden.yubico.server }}
             - name: YUBICO_SERVER
@@ -246,6 +266,10 @@ spec:
             - name: LOG_TIMESTAMP_FORMAT
               value: {{ .Values.vaultwarden.log.timeFormat | quote }}
             {{- end }}
+            {{- if hasKey .Values.vaultwarden.icons "service" }}
+            - name: ICON_SERVICE
+              value: {{ .Values.vaultwarden.icons.service | quote }}
+            {{- end }}              
             {{- if .Values.vaultwarden.icons.disableDownload }}
             - name: DISABLE_ICON_DOWNLOAD
               value: {{ .Values.vaultwarden.icons.disableDownload | quote }}
@@ -262,6 +286,10 @@ spec:
             - name: ICON_CACHE_NEGTTL
               value: {{ .Values.vaultwarden.icons.cacheFailed }}
             {{- end }}
+            {{- if hasKey .Values.vaultwarden.icons "redirectCode" }}
+            - name: ICON_REDIRECT_CODE
+              value: {{ .Values.vaultwarden.icons.redirectCode | quote }}
+            {{- end }}  
           ports:
             - name: http
               containerPort: 8080

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -161,14 +161,21 @@ spec:
             - name: SMTP_FROM_NAME
               value: {{ .Values.vaultwarden.smtp.fromName | quote }}
             {{- end }}
+            {{- if semverCompare "<1.25.0" }}
+              {{- required "ATTENTION - variables SMTP_SSL and SMTP_EXPLICIT_TLS are depraceted in Vaultwared 1.25.0 and above." nil }}
             - name: SMTP_SSL
               value: {{ .Values.vaultwarden.smtp.ssl | quote }}
-            {{- if .Values.vaultwarden.smtp.explicitTLS }}
-              {{- if (eq .Values.vaultwarden.smtp.ssl false) }}
-                {{- required "Explicit TLS requires SSL to be enabled" nil }}
-              {{- end }}
+              {{- if .Values.vaultwarden.smtp.explicitTLS }}
+                {{- if (eq .Values.vaultwarden.smtp.ssl false) }}
+                  {{- required "Explicit TLS requires SSL to be enabled" nil }}
+                {{- end }}
             - name: SMTP_EXPLICIT_TLS
               value: {{ .Values.vaultwarden.smtp.explicitTLS | quote }}
+            {{- else if semverCompare ">=1.25.0" }}
+              {{- if .Values.vaultwarden.smtp.security }}
+            - name: SMTP_SECURITY
+              value: {{ .Values.vaultwarden.smtp.security | quote }}
+              {{- end }}
             {{- end }}
             {{- if .Values.vaultwarden.smtp.port }}
             - name: SMTP_PORT

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -86,10 +86,8 @@ vaultwarden:
     from: ""
     ## SMTP sender name, defaults to 'Vaultwarden'.
     #fromName: ""
-    # Enable SSL connection.
-    ssl: true
-    ## Use Explicit TLS mode, requires that 'ssl' is enabled.
-    #explicitTLS: false
+    # Enable secure SSL connection. Options are: "starttls" which equals the old option "SMTP_SSL=true", "force_tls" which equals the old option "SMTP_EXPLICIT_TLS=true" and "off"
+    security: off
     ## SMTP port. Defaults to 25 without SSL, 587 with SSL.
     #port: 587
     ## SMTP Authentication Mechanisms. Comma-separated options: 'Plain', 'Login' and 'Xoauth2'. Defaults to 'Plain'.

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -33,6 +33,11 @@ vaultwarden:
   #emailTokenExpiration: 600
   # Allow invited users to sign-up even feature is disabled: https://github.com/dani-garcia/vaultwarden/wiki/Disable-invitations
   allowInvitation: true
+  ## Number of hours after which an organization invite token, emergency access invite token,
+  ## email verification token and deletion request token will expire
+  #invitationExpiration: 120
+  ## Allow users to set password hints. Applies to all users.
+  #passwordHintsAllowed: true
   # Show password hints: https://github.com/dani-garcia/vaultwarden/wiki/Password-hint-display
   showPasswordHint: false
   ## Default organization name in invitation e-mails that are not coming from a specific organization.
@@ -54,6 +59,10 @@ vaultwarden:
   #hibpApiKey: 
   ## Number of days to auto-delete trashed items. By default iteams are not auto-deleted.
   #autoDeleteDays: 
+  ## Organization event logging
+  #orgEvents: false
+  ## Organization event retation. Leave empty to not delete.
+  #orgEventsRetention: ""
   ## Map of custom environment variables. Use carefully.
   #extraEnv:
   #  IP_HEADER: CF-Connecting-IP
@@ -110,6 +119,8 @@ vaultwarden:
     #password: ""
     ## Use existing secret for SMTP authentication. Keys are 'smtp-user' and 'smtp-password'.
     #existingSecret:
+    ## Embed images as email attachments
+    #embedImages: false
 
   ## Enable Yubico OPT authentication. https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Yubikey-OTP-authentication
   yubico:
@@ -132,12 +143,16 @@ vaultwarden:
     #timeFormat: ""
 
   icons:
-    # Disables download of external icons. Setting to true will still serve icons from cache (/data/icon_cache). TTL will default to zero.
+    ## Icon download service. "internal" to fetch icons directly, otherwise options are: "bitwarden", "duckduckgo" or "google"
+    #service: internal
+    # Disables download of external icons on internal service. Setting to true will still serve icons from cache (/data/icon_cache). TTL will default to zero.
     disableDownload: false
     ## Cache time-to-live for icons fetched. 0 means no purging.
     #cache: 2592000
     ## Cache time-to-live for icons that were not available. 0 means no purging.
     #cacheFailed: 259200
+    ## HTTP code for redirect to external icon service
+    #redirectCode: 302
 
 service:
   type: ClusterIP

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -73,9 +73,9 @@ vaultwarden:
     # Allow any user to enable emergency access.
     enabled: true
     ## Schedule to send expiration reminders to emergency access grantors. Cron schedule format.
-    #reminder: "0 5 * * * *"
+    #reminder: "0 3 * * * *"
     ## Schedule to grant emergency access requests that have met the required wait time. Cron schedule format.
-    #timeout: "0 5 * * * *"
+    #timeout: "0 3 * * * *"
 
   # Enable SMTP. https://github.com/dani-garcia/vaultwarden/wiki/SMTP-configuration
   smtp:
@@ -86,9 +86,13 @@ vaultwarden:
     from: ""
     ## SMTP sender name, defaults to 'Vaultwarden'.
     #fromName: ""
-    # Enable secure SSL connection. Options are: "starttls" which equals the old option "SMTP_SSL=true", "force_tls" which equals the old option "SMTP_EXPLICIT_TLS=true" and "off"
-    security: off
-    ## SMTP port. Defaults to 25 without SSL, 587 with SSL.
+    # Enable secure SSL connection. Options are: "starttls", "force_tls" and "off"
+    # Users migrating from 1.24 or lower using ssl/explicitTLS settings:
+    #   ssl = false -> "off"
+    #   ssl = true and explicitTLS = false -> "starttls"
+    #   ssl = true and explicitTLS = true -> "force_tls"
+    security: starttls
+    ## SMTP port. Defaults depends on security: 465 for "force_tls", 587 for "starttls" and 25 for "off"
     #port: 587
     ## SMTP Authentication Mechanisms. Comma-separated options: 'Plain', 'Login' and 'Xoauth2'. Defaults to 'Plain'.
     #authMechanism: Plain


### PR DESCRIPTION
Upgrade chart to Vaultwarden v1.27. Chart major version change as SMTP settings are not backwards compatible (see README for details). Thanks @lord-kyron for the initial code to handle SMTP upgrades (#36).

Closes #35
Closes #31