### PR TITLE
Vaultwarden: Add option to specify key for existing database secret

### DIFF
--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -33,6 +33,7 @@ database.type | Backend database type | sqlite, mysql or postgresql | sqlite
 database.wal | Enable SQLite Write-Ahead-Log, ignored for external databases | true / false | true
 database.url | URL of external database (MySQL/PostgreSQL) | \[mysql\|postgresql\]://user:pass@host:port\[/database\] | Empty
 database.existingSecret | Use existing secret for database URL, key 'database-url' | Secret name  | Not defined
+database.existingSecretKey | Use different key for existing secret for database URL. If defined, `database.existingSecret` has to be defined as well | Secret name | Not defined
 database.maxConnections | Set the size of the database connection pool | Number  | 10
 database.retries | Connection retries during startup, 0 for infinite. 1 second between retries | Number | 15
 

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ if .Values.database.existingSecret }}{{ .Values.database.existingSecret }}{{else}}{{ include "vaultwarden.fullname" . }}{{end}}
-                  key: database-url
+                  key: {{ if and .Values.database.existingSecret .Values.database.existingSecretKey }}{{ .Values.database.existingSecretKey }}{{else}}database-url{{end}}
             {{- end }}
             {{- if .Values.vaultwarden.domain }}
             - name: DOMAIN

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -9,6 +9,8 @@ database:
   #url: ""
   ## Use existing secret for database URL, key 'database-url'.
   #existingSecret:
+  ## Use a different key for the existing secret.
+  #existingSecretKey:
   ## Set the size of the database connection pool.
   #maxConnections: 10
   ## Connection retries during startup, 0 for infinite. 1 second between retries.


### PR DESCRIPTION
I added an option to specify a secret key other than 'database-url' for the database secret. 