### PR TITLE
Update template to make it stable ingress api pathType is mandatory

### DIFF
--- a/leantime/templates/ingress.yaml
+++ b/leantime/templates/ingress.yaml
@@ -33,6 +33,7 @@ spec:
       http:
         paths:
           - path: "/"
+            pathType: Prefix
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}


### PR DESCRIPTION
Now in stable ingress api  pathType is mandatory

since
Kubernetes v1.19 [stable]

I think we must delete the old API capacibility 

i cannot install in k3s
because of this error when i enable ingress 
spec.rules[0].http.paths[0].pathType: Required value: pathType must be specified

we must maybe add some test and propose to leantime to help to maintain the helm chart ? 

Thanks again im searking for tdah task tools because you know how life is hard ^