### PR TITLE
feat: add possibility to reference envs

### DIFF
--- a/vaultwarden/Chart.yaml
+++ b/vaultwarden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vaultwarden
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.30.5
 icon: https://upload.wikimedia.org/wikipedia/commons/0/03/Bitwarden_Logo.png
 home: https://github.com/dani-garcia/vaultwarden

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -64,11 +64,7 @@ vaultwarden.autoDeleteDays | Number of days to auto-delete trashed items. | Numb
 vaultwarden.orgEvents | Enable Organization event logging | true / false | false
 vaultwarden.orgEventsRetention | Organization event log retention in days | Number | Empty (never delete)
 vaultwarden.emailChangeAllowed | Allow users to change their email. | true / false | true
-vaultwarden.extraEnv | Pass extra environment variables | Map | Not defined
-vaultwarden.extraEnvFromSecret | Pass extra environment variables by mounting all keys of the referenced secret | Secret name | Not defined
-vaultwarden.extraEnvFromConfigMap | Pass extra environment variables by mounting all keys of the referenced config map | Config map name | Not defined
-vaultwarden.extraEnvFromSecretKey | Inject extra environment variables from secret key | Map | Not defined
-vaultwarden.extraEnvFromConfigMapKey | Inject extra environment variables from config map key | Map | Not defined
+vaultwarden.extraEnv | Pass extra environment variables, either as key-value pairs or as key-reference pairs | Map | Not defined
 vaultwarden.log.file | Filename to log to disk. [More information](https://github.com/dani-garcia/vaultwarden/wiki/Logging) | File path | Empty
 vaultwarden.log.level | Change log level | trace, debug, info, warn, error or off | Empty
 vaultwarden.log.timeFormat | Log timestamp | Rust chrono [format](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html). | Empty

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -65,6 +65,8 @@ vaultwarden.orgEvents | Enable Organization event logging | true / false | false
 vaultwarden.orgEventsRetention | Organization event log retention in days | Number | Empty (never delete)
 vaultwarden.emailChangeAllowed | Allow users to change their email. | true / false | true
 vaultwarden.extraEnv | Pass extra environment variables | Map | Not defined
+vaultwarden.extraEnvFromSecretKey | Inject extra environment variables from secret key | Map | Not defined
+vaultwarden.extraEnvFromConfigMapKey | Inject extra environment variables from config map key | Map | Not defined
 vaultwarden.log.file | Filename to log to disk. [More information](https://github.com/dani-garcia/vaultwarden/wiki/Logging) | File path | Empty
 vaultwarden.log.level | Change log level | trace, debug, info, warn, error or off | Empty
 vaultwarden.log.timeFormat | Log timestamp | Rust chrono [format](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html). | Empty

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -65,6 +65,8 @@ vaultwarden.orgEvents | Enable Organization event logging | true / false | false
 vaultwarden.orgEventsRetention | Organization event log retention in days | Number | Empty (never delete)
 vaultwarden.emailChangeAllowed | Allow users to change their email. | true / false | true
 vaultwarden.extraEnv | Pass extra environment variables | Map | Not defined
+vaultwarden.extraEnvFromSecret | Pass extra environment variables by mounting all keys of the referenced secret | Secret name | Not defined
+vaultwarden.extraEnvFromConfigMap | Pass extra environment variables by mounting all keys of the referenced config map | Config map name | Not defined
 vaultwarden.extraEnvFromSecretKey | Inject extra environment variables from secret key | Map | Not defined
 vaultwarden.extraEnvFromConfigMapKey | Inject extra environment variables from config map key | Map | Not defined
 vaultwarden.log.file | Filename to log to disk. [More information](https://github.com/dani-garcia/vaultwarden/wiki/Logging) | File path | Empty

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -335,6 +335,17 @@ spec:
               value: {{ .Values.vaultwarden.push.identityUri | quote }}
             {{- end }}
             {{- end }}{{/* Push */}}
+          {{- if or .Values.vaultwarden.extraEnvFromSecret .Values.vaultwarden.extraEnvFromConfigMap }}
+          envFrom:
+            {{- if .Values.vaultwarden.extraEnvFromSecret }}
+            - secretRef:
+                name: {{ .Values.vaultwarden.extraEnvFromSecret | quote }}
+            {{- end }}
+            {{- if .Values.vaultwarden.extraEnvFromConfigMap }}
+            - configMapRef:
+                name: {{ .Values.vaultwarden.extraEnvFromConfigMap | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -123,25 +123,14 @@ spec:
             {{- if .Values.vaultwarden.extraEnv }}
             {{- range $key, $val := .Values.vaultwarden.extraEnv }}
             - name: {{ $key }}
+            {{- if kindIs "string" $val }}
               value: {{ $val | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.vaultwarden.extraEnvFromSecretKey }}
-            {{- range $key, $ref := .Values.vaultwarden.extraEnvFromSecretKey }}
-            - name: {{ $key | quote }}
+            {{- else if or (hasKey $val "secretKeyRef") (hasKey $val "configMapKeyRef") }}
               valueFrom:
-                secretKeyRef:
-                  name: {{ $ref.name | quote }}
-                  key: {{ $ref.key | quote }}
+                {{- $val | toYaml | nindent 16 }}
+            {{- else }}
+            {{- fail "if vaultwarden.extraEnv is defined you need to assign strings or a valid valueFrom key (configMapKeyRef or secretKeyRef) to it" }}
             {{- end }}
-            {{- end }}
-            {{- if .Values.vaultwarden.extraEnvFromConfigMapKey }}
-            {{- range $key, $ref := .Values.vaultwarden.extraEnvFromConfigMapKey }}
-            - name: {{ $key | quote }}
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ $ref.name | quote }}
-                  key: {{ $ref.key | quote }}
             {{- end }}
             {{- end }}
             {{- include "vaultwarden.dbTypeValid" . }}
@@ -300,7 +289,7 @@ spec:
               value: {{ .Values.vaultwarden.icons.disableDownload | quote }}
               {{- if and (not .Values.vaultwarden.icons.cache) (.Values.vaultwarden.icons.disableDownload) }}
             - name: ICON_CACHE_TTL
-              value: 0
+              value: "0"
               {{- end }}
             {{- end }}
             {{- if .Values.vaultwarden.icons.cache }}
@@ -335,17 +324,6 @@ spec:
               value: {{ .Values.vaultwarden.push.identityUri | quote }}
             {{- end }}
             {{- end }}{{/* Push */}}
-          {{- if or .Values.vaultwarden.extraEnvFromSecret .Values.vaultwarden.extraEnvFromConfigMap }}
-          envFrom:
-            {{- if .Values.vaultwarden.extraEnvFromSecret }}
-            - secretRef:
-                name: {{ .Values.vaultwarden.extraEnvFromSecret | quote }}
-            {{- end }}
-            {{- if .Values.vaultwarden.extraEnvFromConfigMap }}
-            - configMapRef:
-                name: {{ .Values.vaultwarden.extraEnvFromConfigMap | quote }}
-            {{- end }}
-          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -126,6 +126,24 @@ spec:
               value: {{ $val | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.vaultwarden.extraEnvFromSecretKey }}
+            {{- range $key, $ref := .Values.vaultwarden.extraEnvFromSecretKey }}
+            - name: {{ $key | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $ref.name | quote }}
+                  key: {{ $ref.key | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.vaultwarden.extraEnvFromConfigMapKey }}
+            {{- range $key, $ref := .Values.vaultwarden.extraEnvFromConfigMapKey }}
+            - name: {{ $key | quote }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $ref.name | quote }}
+                  key: {{ $ref.key | quote }}
+            {{- end }}
+            {{- end }}
             {{- include "vaultwarden.dbTypeValid" . }}
             {{- if .Values.database.retries }}
             - name: DB_CONNECTION_RETRIES

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -70,6 +70,20 @@ vaultwarden:
   #extraEnv:
   #  IP_HEADER: CF-Connecting-IP
   #  ALLOWED_IFRAME_ANCESTORS: myintranet.local
+  #extraEnvFromSecretKey:
+  #  IP_HEADER:
+  #    name: ip-header-secret
+  #    key: ip-header-key
+  #  ALLOWED_IFRAME_ANCESTORS:
+  #    name: allowed-iframe-ancestors-secret
+  #    key: allowed-iframe-ancestors-key
+  #extraEnvFromConfigMapKey:
+  #  IP_HEADER:
+  #    name: ip-header-config-map
+  #    key: ip-header-key
+  #  ALLOWED_IFRAME_ANCESTORS:
+  #    name: allowed-iframe-ancestors-config-map
+  #    key: allowed-iframe-ancestors-key
 
   admin:
     # Enable admin portal.

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -19,7 +19,7 @@ database:
 # Set vaultwarden application variables
 vaultwarden:
   ## Set Bitwarden URL, mandatory for invitations over email. Recommended if using a reverse proxy / ingress. Format is https://name or http://name
-  #domain:
+  #domain: 
   # Allow any user to sign-up: https://github.com/dani-garcia/vaultwarden/wiki/Disable-registration-of-new-users
   allowSignups: true
   ## Whitelist domains allowed to sign-up. 'allowSignups' is ignored if set.
@@ -46,20 +46,20 @@ vaultwarden:
   #defaultInviteName: ""
   # Enable Web Vault (static content). https://github.com/dani-garcia/vaultwarden/wiki/Disabling-or-overriding-the-Vault-interface-hosting
   enableWebVault: true
-  # Enable Bitwarden Sends globally
+  # Enable Bitwarden Sends globally  
   enableSends: true
   # Restrict creation of orgs. Options are: 'all', 'none' or a comma-separated list of users.
   orgCreationUsers: all
   ## Limit attachment disk usage per organization.
-  #attachmentLimitOrg:
+  #attachmentLimitOrg: 
   ## Limit attachment disk usage per user.
-  #attachmentLimitUser:
+  #attachmentLimitUser: 
   ## Limit send disk usage per user.
   #sendLimitUser:
   ## HaveIBeenPwned API Key. Can be purchased at https://haveibeenpwned.com/API/Key.
-  #hibpApiKey:
+  #hibpApiKey: 
   ## Number of days to auto-delete trashed items. By default iteams are not auto-deleted.
-  #autoDeleteDays:
+  #autoDeleteDays: 
   ## Organization event logging
   #orgEvents: false
   ## Organization event retation. Leave empty to not delete.
@@ -70,22 +70,14 @@ vaultwarden:
   #extraEnv:
   #  IP_HEADER: CF-Connecting-IP
   #  ALLOWED_IFRAME_ANCESTORS: myintranet.local
-  #extraEnvFromSecret: my-secret
-  #extraEnvFromConfigMap: my-config-map
-  #extraEnvFromSecretKey:
-  #  IP_HEADER:
-  #    name: ip-header-secret
-  #    key: ip-header-key
-  #  ALLOWED_IFRAME_ANCESTORS:
-  #    name: allowed-iframe-ancestors-secret
-  #    key: allowed-iframe-ancestors-key
-  #extraEnvFromConfigMapKey:
-  #  IP_HEADER:
-  #    name: ip-header-config-map
-  #    key: ip-header-key
-  #  ALLOWED_IFRAME_ANCESTORS:
-  #    name: allowed-iframe-ancestors-config-map
-  #    key: allowed-iframe-ancestors-key
+  #  COOL_VARIABLE:
+  #    secretKeyRef:
+  #      name: my-secret
+  #      key: my-secret-key
+  #  ANOTHER_VARIABLE:
+  #    configMapKeyRef:
+  #      name: my-config-map
+  #      key: my-config-map-key
 
   admin:
     # Enable admin portal.
@@ -93,10 +85,10 @@ vaultwarden:
     # Disabling the admin token will make the admin portal accessible to anyone, use carefully: https://github.com/dani-garcia/vaultwarden/wiki/Disable-admin-token
     disableAdminToken: false
     ## Token for admin login, will be generated if not defined. https://github.com/dani-garcia/vaultwarden/wiki/Enabling-admin-page
-    #token:
+    #token: 
     ## Use existing secret for the admin token. Key is 'admin-token'.
     #existingSecret:
-
+  
   emergency:
     # Allow any user to enable emergency access.
     enabled: true
@@ -150,13 +142,13 @@ vaultwarden:
     #clientId:
     #secretKey:
     ## Use existing secret for Yubico. Keys are 'yubico-client-id' and 'yubico-secret-key'.
-    #existingSecret:
+    #existingSecret: 
 
   ## Logging options. https://github.com/dani-garcia/vaultwarden/wiki/Logging
   log:
     # Log to file.
     file: ""
-    # Log level. Options are "trace", "debug", "info", "warn", "error" or "off".
+    # Log level. Options are "trace", "debug", "info", "warn", "error" or "off". 
     level: ""
     ## Log timestamp format. See https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html. Defaults to time in milliseconds.
     #timeFormat: ""
@@ -183,7 +175,7 @@ vaultwarden:
     ## Relay URI
     #relayUri:
     ## Identity URI
-    #identityUri:
+    #identityUri: 
     ## Use existing secret for Push notifications. Keys are 'push-id' and 'push-key'.
     #existingSecret:
 
@@ -201,8 +193,7 @@ ingress:
   enabled: false
   className: ""
   host: ""
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls: []
@@ -223,8 +214,7 @@ ingressRoute:
   middlewares: {}
   #  - name: my_middleware
   #    namespace: default
-  tls:
-    {}
+  tls: {}
     #certResolver: letsencrypt
 
 persistence:
@@ -239,8 +229,7 @@ persistence:
   annotations: {}
 
 # Use custom volume definition. Cannot be used with persistence.
-customVolume:
-  {}
+customVolume: {}
   #hostPath:
   #  path: "/examplefolder/vaultwarden"
 
@@ -273,18 +262,17 @@ podLabels: {}
 # Annotations to add to the Deployment
 deploymentAnnotations: {}
 # Readiness and Liveness probes
-probes:
-  {}
+probes: {}
   #liveness:
-  #timeoutSeconds: 1
-  #periodSeconds: 10
-  #successThreshold: 1
-  #failureThreshold: 3
+    #timeoutSeconds: 1
+    #periodSeconds: 10
+    #successThreshold: 1
+    #failureThreshold: 3
   #readiness:
-  #timeoutSeconds: 1
-  #periodSeconds: 10
-  #successThreshold: 1
-  #failureThreshold: 3
+    #timeoutSeconds: 1
+    #periodSeconds: 10
+    #successThreshold: 1
+    #failureThreshold: 3
 
 # Sidecar containers, add container spec (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
 # No templating possible, values need to be hardcoded
@@ -307,8 +295,7 @@ securityContext:
 
 strategy: {}
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -19,7 +19,7 @@ database:
 # Set vaultwarden application variables
 vaultwarden:
   ## Set Bitwarden URL, mandatory for invitations over email. Recommended if using a reverse proxy / ingress. Format is https://name or http://name
-  #domain: 
+  #domain:
   # Allow any user to sign-up: https://github.com/dani-garcia/vaultwarden/wiki/Disable-registration-of-new-users
   allowSignups: true
   ## Whitelist domains allowed to sign-up. 'allowSignups' is ignored if set.
@@ -46,20 +46,20 @@ vaultwarden:
   #defaultInviteName: ""
   # Enable Web Vault (static content). https://github.com/dani-garcia/vaultwarden/wiki/Disabling-or-overriding-the-Vault-interface-hosting
   enableWebVault: true
-  # Enable Bitwarden Sends globally  
+  # Enable Bitwarden Sends globally
   enableSends: true
   # Restrict creation of orgs. Options are: 'all', 'none' or a comma-separated list of users.
   orgCreationUsers: all
   ## Limit attachment disk usage per organization.
-  #attachmentLimitOrg: 
+  #attachmentLimitOrg:
   ## Limit attachment disk usage per user.
-  #attachmentLimitUser: 
+  #attachmentLimitUser:
   ## Limit send disk usage per user.
   #sendLimitUser:
   ## HaveIBeenPwned API Key. Can be purchased at https://haveibeenpwned.com/API/Key.
-  #hibpApiKey: 
+  #hibpApiKey:
   ## Number of days to auto-delete trashed items. By default iteams are not auto-deleted.
-  #autoDeleteDays: 
+  #autoDeleteDays:
   ## Organization event logging
   #orgEvents: false
   ## Organization event retation. Leave empty to not delete.
@@ -70,6 +70,8 @@ vaultwarden:
   #extraEnv:
   #  IP_HEADER: CF-Connecting-IP
   #  ALLOWED_IFRAME_ANCESTORS: myintranet.local
+  #extraEnvFromSecret: my-secret
+  #extraEnvFromConfigMap: my-config-map
   #extraEnvFromSecretKey:
   #  IP_HEADER:
   #    name: ip-header-secret
@@ -91,10 +93,10 @@ vaultwarden:
     # Disabling the admin token will make the admin portal accessible to anyone, use carefully: https://github.com/dani-garcia/vaultwarden/wiki/Disable-admin-token
     disableAdminToken: false
     ## Token for admin login, will be generated if not defined. https://github.com/dani-garcia/vaultwarden/wiki/Enabling-admin-page
-    #token: 
+    #token:
     ## Use existing secret for the admin token. Key is 'admin-token'.
     #existingSecret:
-  
+
   emergency:
     # Allow any user to enable emergency access.
     enabled: true
@@ -148,13 +150,13 @@ vaultwarden:
     #clientId:
     #secretKey:
     ## Use existing secret for Yubico. Keys are 'yubico-client-id' and 'yubico-secret-key'.
-    #existingSecret: 
+    #existingSecret:
 
   ## Logging options. https://github.com/dani-garcia/vaultwarden/wiki/Logging
   log:
     # Log to file.
     file: ""
-    # Log level. Options are "trace", "debug", "info", "warn", "error" or "off". 
+    # Log level. Options are "trace", "debug", "info", "warn", "error" or "off".
     level: ""
     ## Log timestamp format. See https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html. Defaults to time in milliseconds.
     #timeFormat: ""
@@ -181,7 +183,7 @@ vaultwarden:
     ## Relay URI
     #relayUri:
     ## Identity URI
-    #identityUri: 
+    #identityUri:
     ## Use existing secret for Push notifications. Keys are 'push-id' and 'push-key'.
     #existingSecret:
 
@@ -199,7 +201,8 @@ ingress:
   enabled: false
   className: ""
   host: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls: []
@@ -220,7 +223,8 @@ ingressRoute:
   middlewares: {}
   #  - name: my_middleware
   #    namespace: default
-  tls: {}
+  tls:
+    {}
     #certResolver: letsencrypt
 
 persistence:
@@ -235,7 +239,8 @@ persistence:
   annotations: {}
 
 # Use custom volume definition. Cannot be used with persistence.
-customVolume: {}
+customVolume:
+  {}
   #hostPath:
   #  path: "/examplefolder/vaultwarden"
 
@@ -268,17 +273,18 @@ podLabels: {}
 # Annotations to add to the Deployment
 deploymentAnnotations: {}
 # Readiness and Liveness probes
-probes: {}
+probes:
+  {}
   #liveness:
-    #timeoutSeconds: 1
-    #periodSeconds: 10
-    #successThreshold: 1
-    #failureThreshold: 3
+  #timeoutSeconds: 1
+  #periodSeconds: 10
+  #successThreshold: 1
+  #failureThreshold: 3
   #readiness:
-    #timeoutSeconds: 1
-    #periodSeconds: 10
-    #successThreshold: 1
-    #failureThreshold: 3
+  #timeoutSeconds: 1
+  #periodSeconds: 10
+  #successThreshold: 1
+  #failureThreshold: 3
 
 # Sidecar containers, add container spec (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
 # No templating possible, values need to be hardcoded
@@ -301,7 +307,8 @@ securityContext:
 
 strategy: {}
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
Added the possibility to reference ConfigMap and Secret keys as env variables. For implementing this the existing style of `vaultwarden.extraEnv` was used as inspiration so that the API design is more consistent.

Closes #55