### PR TITLE
Fix keywords in Chart.yaml

### DIFF
--- a/vaultwarden/Chart.yaml
+++ b/vaultwarden/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.2.4
 appVersion: 1.32.5
 icon: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/vaultwarden-icon.svg
-home: https://github.com/gissilabs/charts/vaultwarden
+home: https://github.com/dani-garcia/vaultwarden
 keywords:
   - bitwarden
   - bitwarden_rs

--- a/vaultwarden/Chart.yaml
+++ b/vaultwarden/Chart.yaml
@@ -5,7 +5,8 @@ type: application
 version: 1.2.4
 appVersion: 1.32.5
 icon: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/vaultwarden-icon.svg
-home: https://github.com/dani-garcia/vaultwarden
+home: https://github.com/gissilabs/charts/vaultwarden
+keywords:
   - bitwarden
   - bitwarden_rs
   - password


### PR DESCRIPTION
Hi, I've noticed that there is the `keywords:` label missing.

This causes broken descriptions in pull-requests generated by [renovate](https://github.com/renovatebot/renovate).

![Screenshot 2024-11-18 at 17 15 14](https://github.com/user-attachments/assets/86177dd1-5455-4745-8669-1073ceee029d)

Also I would like to propose changing the `home:` URL the helm-chart one instead of the source repo of vaultwarden.