### PR TITLE
feat: add posibitily to set revisionHistoryLimit

### DIFF
--- a/leantime/README.md
+++ b/leantime/README.md
@@ -191,6 +191,7 @@ Option | Description | Format | Default
 ------ | ----------- | ------ | -------
 strategy | Deployment Strategy options | sub-tree | Empty
 replicaCount | Number of pod replicas | Number | 1
+revisionHistoryLimit | revisionHistoryLimit | Number | 10
 nameOverride | Name override | Text | Empty
 fullnameOverride | Full name override | Text | Empty
 serviceAccount.create | Create Service Account | true / false | false

--- a/leantime/templates/deployment.yaml
+++ b/leantime/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "leantime.selectorLabels" . | nindent 6 }}

--- a/leantime/values.yaml
+++ b/leantime/values.yaml
@@ -263,6 +263,8 @@ image:
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -169,6 +169,7 @@ Option | Description | Format | Default
 ------ | ----------- | ------ | -------
 strategy | Deployment Strategy options | sub-tree | Empty
 replicaCount | Number of pod replicas | Number | 1
+revisionHistoryLimit | revisionHistoryLimit | Number | 10
 nameOverride | Name override | Text | Empty
 fullnameOverride | Full name override | Text | Empty
 serviceAccount.create | Create Service Account | true / false | false

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "vaultwarden.selectorLabels" . | nindent 6 }}

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -247,6 +247,8 @@ fullnameOverride: ""
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false


### PR DESCRIPTION
Allow setting revisionHistoryLimit.
revisionHistoryLimit is set to its default value of 10, so without user changes in values.yaml, this MR just does nothing.

In the context of gitops, people sometimes change the value to 0.
Others may want to increase the values for other use-cases.

Thanks! 