### PR TITLE
feat: Allow setting automountServiceAccountToken

### DIFF
--- a/leantime/README.md
+++ b/leantime/README.md
@@ -196,6 +196,8 @@ fullnameOverride | Full name override | Text | Empty
 serviceAccount.create | Create Service Account | true / false | false
 serviceAccount.annotations | Annotations service account | Map | Empty
 serviceAccount.name | Service Account name | Text | Generated from template
+serviceAccount.automountServiceAccountToken | Allows auto mount of ServiceAccountToken on the serviceAccount created | true / false | true
+automountServiceAccountToken | Mount Service Account token in pod | true / false | true
 deploymentAnnotations | Deployment Annotations | Map | Empty
 probes.liveness | Liveness options [Spec](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) | Map | Empty
 probes.readiness | Readiness options [Spec](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) | Map | Empty

--- a/leantime/templates/deployment.yaml
+++ b/leantime/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "leantime.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/leantime/templates/serviceaccount.yaml
+++ b/leantime/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/leantime/values.yaml
+++ b/leantime/values.yaml
@@ -298,11 +298,11 @@ serviceAccount:
   ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
   ## Can be set to false if pods using this serviceAccount do not need to use K8s API
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
 
 ## @param automountServiceAccountToken Mount Service Account token in pod
 ##
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 
 # Annotations to add to the Deployment
 deploymentAnnotations: {}

--- a/leantime/values.yaml
+++ b/leantime/values.yaml
@@ -261,6 +261,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
 replicaCount: 1
 
 serviceAccount:
@@ -271,10 +275,14 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: true
 
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: true
 
 # Annotations to add to the Deployment
 deploymentAnnotations: {}

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -174,6 +174,8 @@ fullnameOverride | Full name override | Text | Empty
 serviceAccount.create | Create Service Account | true / false | false
 serviceAccount.annotations | Annotations service account | Map | Empty
 serviceAccount.name | Service Account name | Text | Generated from template
+serviceAccount.automountServiceAccountToken | Allows auto mount of ServiceAccountToken on the serviceAccount created | true / false | true
+automountServiceAccountToken | Mount Service Account token in pod | true / false | true
 deploymentAnnotations | Deployment Annotations | Map | Empty
 probes.liveness | Liveness options [Spec](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) | Map | Empty
 probes.readiness | Readiness options [Spec](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) | Map | Empty

--- a/vaultwarden/templates/deployment.yaml
+++ b/vaultwarden/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "vaultwarden.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/vaultwarden/templates/serviceaccount.yaml
+++ b/vaultwarden/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -260,11 +260,11 @@ serviceAccount:
   ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
   ## Can be set to false if pods using this serviceAccount do not need to use K8s API
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
 
 ## @param automountServiceAccountToken Mount Service Account token in pod
 ##
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 
 podAnnotations: {}
 podLabels: {}

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -255,6 +255,14 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: true
+
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: true
 
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
Hi,
This allows users to set automountServiceAccountToken for the ServiceAccount and for the pods of the deployments.
Default values have been set to Kubernetes defaults, to avoid making this a breaking change.
If you want to change these values, you can edit my changes directly :)
Thanks!

PS: I also allowed myself to equalize the order of the keys in the values.yaml of both charts.