### PR TITLE
added labels to pvc

### DIFF
--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -152,6 +152,7 @@ persistence.accessMode | Volume access mode | Text | ReadWriteOnce
 persistence.storageClass | Storage Class | Text | Not defined. Use "-" for default class
 persistence.existingClaim | Use existing PVC | Name of PVC | Not defined
 persistence.annotations | PVC annotations | Map | Empty
+persistence.labels | PVC labels | Map | Empty
 customVolume | Use custom volume definition. Cannot be used with persistence | Map | Empty
 additionalVolumes | Additional volumes definitions, to be used by sidecars [Spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes) | Array | Empty
 

--- a/vaultwarden/templates/pvc.yaml
+++ b/vaultwarden/templates/pvc.yaml
@@ -7,6 +7,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.persistence.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -227,6 +227,8 @@ persistence:
   # existingClaim:
   ## Annotations to add to the Persistent Volume Claim
   annotations: {}
+  ## Labels to add to the Persistent Volume Claim
+  labels: {}
 
 # Use custom volume definition. Cannot be used with persistence.
 customVolume: {}


### PR DESCRIPTION
This pull request introduces support for adding custom labels to the Persistent Volume Claim (PVC) in the Vaultwarden Helm chart. The changes allow users to specify labels in the values file, which will be applied to the PVC metadata alongside annotations.

Persistent Volume Claim metadata enhancements:

* Added a `labels` field to the PVC template (`vaultwarden/templates/pvc.yaml`) that applies user-defined labels from `.Values.persistence.labels` to the PVC metadata.
* Introduced a `labels` key under `persistence` in the values file (`vaultwarden/values.yaml`) to allow users to define custom labels for the PVC.


Labels are used, e.g., to mark a backup pattern for a PVC:
```yaml
  labels: 
    recurring-job.longhorn.io/source: enabled
    recurring-job-group.longhorn.io/low-prio: enabled
```