### PR TITLE
Add support for httpRoute along ingress and ingressRoute

### DIFF
--- a/vaultwarden/README.md.gotmpl
+++ b/vaultwarden/README.md.gotmpl
@@ -59,7 +59,7 @@ Vaultwarden version before v1.25.0 had a [bug/mislabelled](https://github.com/da
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .Values }}
-{{- if not (or (eq .Key "database") (eq .Key "vaultwarden") (eq .Key "service") (eq .Key "ingress") (eq .Key "ingressRoute") (eq .Key "persistence") (eq .Key "image") (eq .Key "serviceAccount") (eq .Key "vaultwarden.admin") (eq .Key "vaultwarden.emergency") (eq .Key "vaultwarden.smtp") (eq .Key "vaultwarden.yubico") (eq .Key "vaultwarden.log") (eq .Key "vaultwarden.icons") (eq .Key "vaultwarden.push")) }}
+{{- if not (or (eq .Key "database") (eq .Key "vaultwarden") (eq .Key "service") (eq .Key "ingress") (eq .Key "ingressRoute") (eq .Key "httpRoute") (eq .Key "persistence") (eq .Key "image") (eq .Key "serviceAccount") (eq .Key "vaultwarden.admin") (eq .Key "vaultwarden.emergency") (eq .Key "vaultwarden.smtp") (eq .Key "vaultwarden.yubico") (eq .Key "vaultwarden.log") (eq .Key "vaultwarden.icons") (eq .Key "vaultwarden.push")) }}
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}

--- a/vaultwarden/templates/NOTES.txt
+++ b/vaultwarden/templates/NOTES.txt
@@ -3,6 +3,9 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}/
 {{- else if .Values.ingressRoute.enabled }}
   http{{ if $.Values.ingressRoute.tls }}s{{ end }}://{{ .Values.ingressRoute.host }}/
+{{- else if .Values.httpRoute.enabled }}
+  Using HTTPRoute, the TLS must be handled at the Gateway level.
+  http://{{ first .Values.httpRoute.hostnames }}/
 {{- else }}
   {{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "vaultwarden.fullname" . }})

--- a/vaultwarden/templates/httproute.yaml
+++ b/vaultwarden/templates/httproute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "vaultwarden.fullname" . -}}
+{{- if not .Values.httpRoute.hostnames }}
+{{- fail "Hostnames required for httpRoute" }}
+{{- end }}
+{{- if not .Values.httpRoute.parentRefs }}
+{{- fail "parentRefs required for httpRoute, see values.yaml" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "vaultwarden.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- tpl (toYaml .Values.httpRoute.parentRefs) $ | nindent 4 }}
+  hostnames:
+    {{- tpl (toYaml .Values.httpRoute.hostnames) $ | nindent 4 }}
+  rules:
+  {{- range $ruleIdx, $rule := .Values.httpRoute.rules }}
+    - matches:
+      {{- tpl (toYaml $rule.matches) $ | nindent 8 }}
+      {{- if $rule.backendRefs }}
+      backendRefs:
+      {{- tpl (toYaml $rule.backendRefs) $ | nindent 8 }}
+      {{- else }}
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $.Values.service.httpPort }}
+          weight: 1
+      {{- end }}
+      {{- if $rule.filters }}
+      filters:
+      {{- tpl (toYaml $rule.filters) $ | nindent 8 }}
+      {{- end }}
+      {{- if $rule.timeouts }}
+      timeouts:
+      {{- tpl (toYaml $rule.timeouts) $ | nindent 8 }}
+      {{- end }}
+  {{- end -}}
+{{- end -}}

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -253,6 +253,44 @@ ingressRoute:
   # -- TLS configuration
   tls: {}
 
+# -- HTTPRoute configuration. ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+httpRoute:
+  # -- Enabled HTTPRoute
+  enabled: false
+  # -- HTTPRoute hostnames
+  hostnames: []
+  # -- HTTPRoute annotations
+  annotations: {}
+  # -- Gateway API parentRefs for the HTTPRoute. Must reference an existing Gateway
+  # e.g:
+  # parentRefs:
+  #   - group: gateway.networking.k8s.io
+  #     kind: Gateway
+  #     name: main-gateway
+  #     namespace: gateway
+  #
+  parentRefs: []
+  # -- (Optional) HTTPRoute rules configuration, if overriden, backendRefs is set by default
+  # e.g:
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /
+  #     filters:
+  #       - type: RequestHeaderModifier
+  #         requestHeaderModifier:
+  #           add:
+  #             - name: X-Custom-Header
+  #               value: custom-value
+  #     timeouts:
+  #       request: 500ms
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
 # -- Persistence configuration
 persistence:
   # -- Enable persistent storage


### PR DESCRIPTION
With the retirement of ingress-nginx project, lots of people (including us) are migrating to HTTPRoute instead of Ingress, because it is becoming the new standard with Gateway API.

It’ll be great if HTTPRoute could be supported out of the box by vaultwarden chart. Thus this PR.

Thanks in advance for the review :)